### PR TITLE
Quick spelling correction

### DIFF
--- a/clojurebot-eval/src/clojurebot/sandbox.clj
+++ b/clojurebot-eval/src/clojurebot/sandbox.clj
@@ -282,7 +282,7 @@
                                   true)
                          r# (pr-str (try
                                       (when-not good?#
-                                        (throw (Exception. "SANBOX DENIED")))
+                                        (throw (Exception. "SANDBOX DENIED")))
                                       (eval f#)
                                       (catch Throwable t#
                                         t#)))]


### PR DESCRIPTION
I noticed in #clojure that `SANBOX` should probably `SANDBOX`.
