### PR TITLE
Corrected spelling of exclusions in project.clj.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [org.ccil.cowan.tagsoup/tagsoup "1.2"]
                  [cheshire "5.0.2"]
                  [clj-http "0.7.2"
-                  :exclude [commons-logging]]
+                  :exclusions [commons-logging]]
                  [swank-clojure "1.3.2"]
                  [com.thelastcitadel/apropos "0.0.1"]
                  [ring "1.1.8"]


### PR DESCRIPTION
I noticed that you had used the singular form of :exclusions in your project.clj. You might want to reconsider why you put the exclusion in there in the first place since the singular form isn't used by leiningen.